### PR TITLE
Make sure the sort is stable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var specificity = require('specificity')
 var flatten = require("flatten")
 var postcss = require("postcss")
+var stableSort = require("stable")
 module.exports = function(selectors){
   if(typeof selectors === "string"){ // raw css
     selectors = parseSelectors(selectors)
@@ -8,9 +9,7 @@ module.exports = function(selectors){
   var specifs = flatten(selectors.map(function(selector){
     return specificity.calculate(selector)
   }))
-  var sorted = specifs.sort(function(a, b){
-    return compare(a,b)
-  })
+  var sorted = stableSort(specifs, compare)
 
   return sorted.map(function(item){
     return item.selector.trim()
@@ -21,7 +20,7 @@ var parseSelectors = function(css){
   var nodes = parsed.root.nodes || []
   return nodes.map(function(node){
     return node.selector
-  })  
+  })
 }
 /**
  * return 1  if a < b(css specificity)
@@ -47,5 +46,5 @@ var compare = module.exports.compare = function(a, b){
       return -1
     }
   }
-  return 1
+  return 0
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "flatten": "0.0.1",
     "postcss": "^4.0.1",
-    "specificity": "^0.1.3"
+    "specificity": "^0.1.3",
+    "stable": "0.1.5"
   }
 }

--- a/test.js
+++ b/test.js
@@ -31,8 +31,8 @@ describe('specificity', function(){
     var result = sortSpecificity(input)
     var expect = [
       ".foo",
-      "div",
       "a",
+      "div",
     ]
     assert.deepEqual(result, expect)
   })
@@ -43,8 +43,8 @@ describe('specificity', function(){
     ]
     var result = sortSpecificity(input)
     var expect = [
-      "a d",
       "a b",
+      "a d",
     ]
     assert.deepEqual(result, expect)
   })
@@ -53,7 +53,7 @@ describe('specificity', function(){
       "a,b.c", "p"
     ]
     var expect =[
-      "b.c", "p", "a"
+      "b.c", "a", "p"
     ]
     var result = sortSpecificity(input)
     assert.deepEqual(result, expect)
@@ -63,7 +63,7 @@ describe('specificity', function(){
       " a "," b "
     ]
     var expect =[
-      "b", "a"
+      "a", "b"
     ]
     var result = sortSpecificity(input)
     assert.deepEqual(result, expect)
@@ -71,8 +71,13 @@ describe('specificity', function(){
   it("input raw css", function(){
     var file = fs.readFileSync("./fixtures/sample.css", "utf-8")
     var result = sortSpecificity(file)
-    var expect = [ 'a .b #c', '.a .b', 'a .b', 'a.b', '.b', '.a' ]
+    var expect = [ 'a .b #c', '.a .b', 'a.b', 'a .b', '.a', '.b' ]
     assert.deepEqual(result, expect)
+  })
+  it("the sort is stable", function(){
+    var input = ['.c', '.b.', '.a']
+    var result = sortSpecificity(input)
+    assert.deepEqual(result, input)
   })
 })
 
@@ -90,7 +95,7 @@ describe("compare", function(){
     assert.equal(sortSpecificity.compare("a", "a b"), 1)
   })
   it("a = b", function(){
-    assert.equal(sortSpecificity.compare("a", "b"), 1)
+    assert.equal(sortSpecificity.compare("a", "b"), 0)
   })
   it("a > b", function(){
     assert.equal(sortSpecificity.compare("b a", "b"), -1)


### PR DESCRIPTION
Hi, thanks for the nice module! We’re using it for our [CSS unit tests](http://tomek.wiszniewski.cc/how-css-unit-tests-boosted-our-productivity/) – unbelievable that you have our unusual use-case covered!

Anyway, in one of our tests we need to be sure that a certain selector has a larger specificity than a bunch of others. The easiest way to be sure is to stick it at the end of the bunch, do a [stable sort](http://programmers.stackexchange.com/a/247441) and make sure it has jumped to the top.

As you can see in the tests, this update changes the current sort order. So you might want to label it as a breaking change.
